### PR TITLE
bump depencency version for apple silicon support & code improvement

### DIFF
--- a/CookieMonster/pom.xml
+++ b/CookieMonster/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.23.1</version>
+			<version>3.40.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>net.java.dev.jna</groupId>

--- a/CookieMonster/src/main/java/cmonster/browsers/ChromeBrowser.java
+++ b/CookieMonster/src/main/java/cmonster/browsers/ChromeBrowser.java
@@ -329,8 +329,8 @@ public class ChromeBrowser extends Browser {
             try {
                 byte[] salt = "saltysalt".getBytes();
                 char[] password = chromeKeyringPassword.toCharArray();
-                char[] iv = new char[16];
-                Arrays.fill(iv, ' ');
+                byte[] iv = new byte[16];
+                Arrays.fill(iv, (byte)' ');
                 int keyLength = 16;
 
                 int iterations = 1003;
@@ -343,7 +343,7 @@ public class ChromeBrowser extends Browser {
                 SecretKeySpec keySpec = new SecretKeySpec(aesKey, "AES");
 
                 Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-                cipher.init(Cipher.DECRYPT_MODE, keySpec, new IvParameterSpec(new String(iv).getBytes()));
+                cipher.init(Cipher.DECRYPT_MODE, keySpec, new IvParameterSpec(iv));
 
                 // if cookies are encrypted "v10" is a the prefix (has to be removed before decryption)
                 byte[] encryptedBytes = encryptedCookie.getEncryptedValue();


### PR DESCRIPTION
1. bumps sqlite-jdbc dependency version to latest, as it contains support M1 apple silicon. (see https://github.com/xerial/sqlite-jdbc/issues/562)
2. minor improvement of variable declaration.