### PR TITLE
Fix issues #12 and #13, build & ChromeBrowser problems

### DIFF
--- a/CookieMonster/pom.xml
+++ b/CookieMonster/pom.xml
@@ -9,8 +9,8 @@
 	<name>Cookie Monster</name>
 
 	<properties>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>1.9</maven.compiler.source>
+		<maven.compiler.target>1.9</maven.compiler.target>
 	</properties>
 
 	<distributionManagement>
@@ -72,7 +72,7 @@
 		          </manifest>
 		        </archive>
                 <descriptorRefs>
-                    <descriptorRef>fat</descriptorRef>
+                    <descriptorRef>jar-with-dependencies</descriptorRef>
                 </descriptorRefs>
             </configuration>
 


### PR DESCRIPTION
Fixes to build process and to ChromeBrowser for current Windows versions of Chrome.

Updated Maven "fat" target to "jar-with-dependencies". Updated Maven source/target JDK version to 1.9.
Updated ChromeBrowser to look for files ending in "Cookies" in any subdirectory, to handle modern Windows Chrome that puts it in Default/Network. Updated ChromeBrowser to skip un-decryptable cookies in Windows, rather than fail with an exception, to match Mac and Linux behavior.

This PR addresses and should resolve issue #12 and issue #13 .

I have successfully rebuilt the fat JAR and updated the file that is checked into the root of the repository with the output from `/CookieMonster/target/CookieMonster-jar-with-dependencies.jar`, and also verified that `new ChromeBrowser().getCookies()` returns the expected, non-empty result with my latest version of Chrome on Windows.